### PR TITLE
Added new action 'get_vm_externalID' and fixed an issue with action 'manage_vm_tag'

### DIFF
--- a/vmware-nsx-t/info.json
+++ b/vmware-nsx-t/info.json
@@ -2,7 +2,7 @@
   "name": "vmware-nsx-t",
   "label": "VMware NSX-T",
   "description": "VMware NSX-T Data Center focuses on providing networking, security, automation, and operational simplicity for emerging application frameworks and architectures that have heterogeneous endpoint environments and technology stacks. This Connector automated operations such as create, update and delete operation related to policy, rule, group etc.",
-  "publisher": "Fortinet",
+  "publisher": "Community",
   "cs_approved": false,
   "cs_compatible": true,
   "version": "1.1.0",

--- a/vmware-nsx-t/info.json
+++ b/vmware-nsx-t/info.json
@@ -1339,6 +1339,27 @@
           "status": "",
           "result": ""
       }
+    },
+    {
+      "operation": "get_vm_externalID",
+      "title": "Get VM External ID",
+      "category": "miscellaneous",
+      "annotation": "get_vm_externalID",
+      "description": "Gets external id of a given VM name. ",
+      "parameters": [
+          {
+              "title": "VM name",
+              "name": "vm_name",
+              "type": "text",
+              "tooltip": "Specify the name of VM.",
+              "description": "Specify the ethe name of VM.",
+              "required": true,
+              "editable": true,
+              "visible": true
+          }
+      ],
+      "enabled": true,
+      "output_schema": {}
     }
   ]
 }

--- a/vmware-nsx-t/info.json
+++ b/vmware-nsx-t/info.json
@@ -1352,7 +1352,7 @@
               "name": "vm_name",
               "type": "text",
               "tooltip": "Specify the name of VM.",
-              "description": "Specify the ethe name of VM.",
+              "description": "Specify the name of VM.",
               "required": true,
               "editable": true,
               "visible": true

--- a/vmware-nsx-t/info.json
+++ b/vmware-nsx-t/info.json
@@ -5,7 +5,7 @@
   "publisher": "Community",
   "cs_approved": false,
   "cs_compatible": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "category": "Network Security",
   "help_online": "https://docs.fortinet.com/document/fortisoar/1.1.0/vmware-nsx-t/543/vmware-nsx-t-v1-1-0",
   "icon_small_name": "small.png",

--- a/vmware-nsx-t/operations.py
+++ b/vmware-nsx-t/operations.py
@@ -34,10 +34,13 @@ class VMwareNSXT(object):
         credentials = (self.username, self.password)
         try:
             response = requests.request(method, service_endpoint, auth=credentials, params=params, data=payload,
-                                        verify=self.verify_ssl)
+                                        verify=self.verify_ssl, headers={"content-type":"application/json", "Accept" : "application/json"})
             logger.debug('API Status Code: {0}'.format(response.status_code))
+            logger.debug('API Response content: {0}'.format(response.content))
             logger.debug('API Response: {0}'.format(response.text))
-            if response.ok:
+            if response.status_code == 204 and response.ok:
+                return {'status': 'success', 'result': 'Policy created/updated successfully.'}
+            elif response.status_code == 200 and response.ok:
                 return json.loads(response.content.decode('utf-8'))
             else:
                 if error_msg.get(response.status_code):

--- a/vmware-nsx-t/operations.py
+++ b/vmware-nsx-t/operations.py
@@ -286,10 +286,22 @@ def manage_vm_tag(config, params):
         elif vm_tag_update_action == 'UPDATE':
             endpoint = f"/api/v1/fabric/virtual-machines?action={action_dict['UPDATE']}"
         params_dict = {"external_id": external_id, "tags": [{"scope": vm_scope, "tag": vm_tag}]}
-        resp = nsx.make_rest_call(endpoint, payload=params_dict, method='POST')
+        resp = nsx.make_rest_call(endpoint, payload=json.dumps(params_dict, indent = 4), method='POST')
+        return json.dumps(resp)
     except Exception as Err:
         logger.error(Err)
         raise ConnectorError(Err)
+    
+def get_vm_externalID(config, params):
+    try:
+      nsx = VMwareNSXT(config)
+      vm_name = params.get('vm_name')
+      endpoint = f"/api/v1/fabric/virtual-machines?display_name={vm_name}&included_fields=tags&included_fields=external_id"
+      resp = nsx.make_rest_call(endpoint, method='GET')
+      return json.dumps(resp)
+    except Exception as Err:
+      logger.error(Err)
+      raise ConnectorError(Err)
 
 
 def _check_health(config):
@@ -316,7 +328,8 @@ operations = {
     'get_rule_details': get_rule_details,
     'upsert_rule': upsert_rule,
     'delete_rule': delete_rule,
-    'manage_vm_tag': manage_vm_tag
+    'manage_vm_tag': manage_vm_tag,
+    'get_vm_externalID': get_vm_externalID
 
 }
 

--- a/vmware-nsx-t/operations.py
+++ b/vmware-nsx-t/operations.py
@@ -38,6 +38,7 @@ class VMwareNSXT(object):
             logger.debug('API Status Code: {0}'.format(response.status_code))
             logger.debug('API Response content: {0}'.format(response.content))
             logger.debug('API Response: {0}'.format(response.text))
+            
             if response.status_code == 204 and response.ok:
                 return {'status': 'success', 'result': 'Policy created/updated successfully.'}
             elif response.status_code == 200 and response.ok:
@@ -294,7 +295,7 @@ def manage_vm_tag(config, params):
     except Exception as Err:
         logger.error(Err)
         raise ConnectorError(Err)
-    
+
 def get_vm_externalID(config, params):
     try:
       nsx = VMwareNSXT(config)
@@ -331,8 +332,6 @@ operations = {
     'get_rule_details': get_rule_details,
     'upsert_rule': upsert_rule,
     'delete_rule': delete_rule,
-    'manage_vm_tag': manage_vm_tag,
-    'get_vm_externalID': get_vm_externalID
-
+    'get_vm_externalID': get_vm_externalID,
+    'manage_vm_tag': manage_vm_tag
 }
-

--- a/vmware-nsx-t/release_notes.md
+++ b/vmware-nsx-t/release_notes.md
@@ -1,3 +1,4 @@
 #### What's Improved
 
-- Added a new action named 'Manage VM TAG'. 
+- Fixed the issue with 'Manage VM TAG'.
+- Added a new action named 'Get VM External ID'. 


### PR DESCRIPTION
Added new action 'get_vm_externalID' and fixed an issue with action 'manage_vm_tag'

#### Descriptions:
New action 'get_vm_externalID' gets external id of a given VM name.

#### Fix:
Rectifying payload to JSON  type for action "Manage VM TAG"

